### PR TITLE
repair a bug about when check tabBar navigate to index

### DIFF
--- a/components/engineer-footer/engineer-foot.js
+++ b/components/engineer-footer/engineer-foot.js
@@ -9,7 +9,6 @@ Component({
         item.selected = (i == this.properties.active);
         return item;
       })
-      console.log(tabs);
       this.setData({
         tabs:tabs
       })
@@ -43,17 +42,14 @@ Component({
   methods: {
     switchTab(e) {
       const index = e.currentTarget.dataset.index;
-      // const tabs = this.data.tabs.map((item, i) => {
-      //   item.selected = i === index;
-      //   return item;
-      // });
-      // this.setData({ tabs });
       wx.navigateTo({
         url: this.data.tabs[index].pagePath
       })
-      wx.switchTab({
-        url: '/pages/index/index',
-      })
+      if(index == 0){
+        wx.switchTab({
+          url: '/pages/index/index',
+        })
+      }
     }
   }
 });


### PR DESCRIPTION
在components\engineer-footer\engineer-foot.js（Line:48）添加了判断tabBar索引以解决在切换tabBar时错误跳转到首页的问题。